### PR TITLE
feat: bump release status to GA

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/vision/docs/",
   "client_documentation": "https://googleapis.dev/python/vision/latest",
   "issue_tracker": "https://issuetracker.google.com/issues?q=status:open%20componentid:187174",
-  "release_level": "beta",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-vision",
   "distribution_name": "google-cloud-vision",

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Python Client for Google Cloud Vision
 =====================================
 
-|beta| |pypi| |versions| 
+|GA| |pypi| |versions| 
 
 The `Google Cloud Vision`_  API enables developers to
 understand the content of an image by encapsulating powerful machine
@@ -17,8 +17,8 @@ Storage.
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |beta| image:: https://img.shields.io/badge/support-beta-silver.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+.. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg
    :target: https://pypi.org/project/google-cloud-vision/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vision.svg

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 name = "google-cloud-vision"
 description = "Cloud Vision API API client library"
 version = "0.42.0"
-release_status = "Development Status :: 4 - Beta"
+release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',


### PR DESCRIPTION
Release-As: 1.0.0

Underlying Vision API is GA.

[GA release template](https://github.com/googleapis/google-cloud-common/issues/287)
## Required 

- [x] 28 days elapsed since last beta release with new API surface
- [x] Server API is GA
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA
