### PR TITLE
fix: Fixes VPCSC Tests that did not conform to V2.0.0 client API

### DIFF
--- a/tests/system.py
+++ b/tests/system.py
@@ -868,7 +868,8 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             bucket=self.test_bucket.name, method_name=method_name
         )
         output_config = {"gcs_destination": {"uri": output_gcs_uri_prefix}}
-        response = self.client.async_batch_annotate_images(requests=[request], output_config=output_config)
+        response = self.client.async_batch_annotate_images(
+            requests=[request], output_config=output_config)
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
         start_time = time.time()
@@ -905,7 +906,8 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             bucket=vpcsc_config.bucket_outside, method_name=method_name
         )
         output_config = {"gcs_destination": {"uri": output_gcs_uri_prefix}}
-        response = self.client.async_batch_annotate_images(requests=[request], output_config=output_config)
+        response = self.client.async_batch_annotate_images(
+            requests=[request], output_config=output_config)
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
         start_time = time.time()

--- a/tests/system.py
+++ b/tests/system.py
@@ -815,7 +815,7 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             "output_config": {"gcs_destination": {"uri": output_gcs_uri_prefix}},
         }
         with pytest.raises(exceptions.Forbidden) as exc:
-            self.client.async_batch_annotate_files([request])
+            self.client.async_batch_annotate_files(request=request)
 
         assert self.gcs_read_error_message in exc.value.message
 
@@ -844,7 +844,7 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             "features": [{"type_": vision.Feature.Type.DOCUMENT_TEXT_DETECTION}],
             "output_config": {"gcs_destination": {"uri": output_gcs_uri_prefix}},
         }
-        response = self.client.async_batch_annotate_files([request])
+        response = self.client.async_batch_annotate_files(request=request)
 
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
@@ -868,7 +868,7 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             bucket=self.test_bucket.name, method_name=method_name
         )
         output_config = {"gcs_destination": {"uri": output_gcs_uri_prefix}}
-        response = self.client.async_batch_annotate_images([request], output_config)
+        response = self.client.async_batch_annotate_images(request=[request], output_config=output_config)
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
         start_time = time.time()

--- a/tests/system.py
+++ b/tests/system.py
@@ -905,7 +905,7 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             bucket=vpcsc_config.bucket_outside, method_name=method_name
         )
         output_config = {"gcs_destination": {"uri": output_gcs_uri_prefix}}
-        response = self.client.async_batch_annotate_images([request], output_config)
+        response = self.client.async_batch_annotate_images(requests=[request], output_config=output_config)
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
         start_time = time.time()

--- a/tests/system.py
+++ b/tests/system.py
@@ -869,7 +869,8 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
         )
         output_config = {"gcs_destination": {"uri": output_gcs_uri_prefix}}
         response = self.client.async_batch_annotate_images(
-            requests=[request], output_config=output_config)
+            requests=[request], output_config=output_config
+        )
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
         start_time = time.time()
@@ -907,7 +908,8 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
         )
         output_config = {"gcs_destination": {"uri": output_gcs_uri_prefix}}
         response = self.client.async_batch_annotate_images(
-            requests=[request], output_config=output_config)
+            requests=[request], output_config=output_config
+        )
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
         start_time = time.time()

--- a/tests/system.py
+++ b/tests/system.py
@@ -815,7 +815,7 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             "output_config": {"gcs_destination": {"uri": output_gcs_uri_prefix}},
         }
         with pytest.raises(exceptions.Forbidden) as exc:
-            self.client.async_batch_annotate_files(request=request)
+            self.client.async_batch_annotate_files(requests=[request])
 
         assert self.gcs_read_error_message in exc.value.message
 
@@ -844,7 +844,7 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             "features": [{"type_": vision.Feature.Type.DOCUMENT_TEXT_DETECTION}],
             "output_config": {"gcs_destination": {"uri": output_gcs_uri_prefix}},
         }
-        response = self.client.async_batch_annotate_files(request=request)
+        response = self.client.async_batch_annotate_files(requests=[request])
 
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
@@ -868,7 +868,7 @@ class TestVisionClientVpcsc(VisionSystemTestBase):
             bucket=self.test_bucket.name, method_name=method_name
         )
         output_config = {"gcs_destination": {"uri": output_gcs_uri_prefix}}
-        response = self.client.async_batch_annotate_images(request=[request], output_config=output_config)
+        response = self.client.async_batch_annotate_images(requests=[request], output_config=output_config)
         # Wait for the operation to complete.
         lro_waiting_seconds = 90
         start_time = time.time()


### PR DESCRIPTION

Fixes #<issue_number_goes_here> 🦕


Following the migration of the client to V2.0.0, these VPCSC specific tests started failing with syntax/typing errors.
This PR uses the keyword argument style for the client methods to fix the broken tests.