### PR TITLE
docs: insert empty lines between methods in generated docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,9 +1,20 @@
 div#python2-eol {
 	border-color: red;
 	border-width: medium;
-} 
+}
 
 /* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }


### PR DESCRIPTION
Add some padding between methods to make it easier to tell where one method ends and the next one begins.

Addresses https://issuetracker.google.com/issues/185122426

Will be followed up with a corresponding synthtool PR to change template.

# After:
![image](https://user-images.githubusercontent.com/8822365/114619802-2a96f480-9c68-11eb-9607-508b81e56730.png)


# Before:
![image](https://user-images.githubusercontent.com/8822365/114619703-12bf7080-9c68-11eb-8207-39d6898628e6.png)

