### PR TITLE
build: use PyPI API key from secret manager

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -26,7 +26,7 @@ python3 -m pip install --upgrade twine wheel setuptools
 export PYTHONUNBUFFERED=1
 
 # Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google_cloud_pypi_password")
+TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-password")
 cd github/python-vision
 python3 setup.py sdist bdist_wheel
-twine upload --username gcloudpypi --password "${TWINE_PASSWORD}" dist/*
+twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -26,7 +26,7 @@ python3 -m pip install --upgrade twine wheel setuptools
 export PYTHONUNBUFFERED=1
 
 # Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-password")
+TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-token")
 cd github/python-vision
 python3 setup.py sdist bdist_wheel
 twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -26,5 +26,5 @@ env_vars: {
 # Tokens needed to report release status back to GitHub
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-password"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-token"
 }

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -23,18 +23,8 @@ env_vars: {
     value: "github/python-vision/.kokoro/release.sh"
 }
 
-# Fetch PyPI password	
-before_action {	
-  fetch_keystore {	
-    keystore_resource {	
-      keystore_config_id: 73713	
-      keyname: "google_cloud_pypi_password"	
-    }	
-  }	
-}
-
 # Tokens needed to report release status back to GitHub
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-password"
 }


### PR DESCRIPTION
For demonstration purposes only, should be deleted once https://github.com/googleapis/synthtool/pull/1040 is merged.

Build is red b/c release is published, but the credentials are sufficient for upload:
```
Uploading distributions to https://upload.pypi.org/legacy/
Uploading google_cloud_vision-2.3.1-py2.py3-none-any.whl

  0%|          | 0.00/459k [00:00<?, ?B/s]
  2%|▏         | 8.00k/459k [00:00<00:17, 26.3kB/s]
 21%|██        | 96.0k/459k [00:00<00:01, 273kB/s]
100%|██████████| 459k/459k [00:01<00:00, 465kB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
File already exists. See https://pypi.org/help/#file-name-reuse for more information.
```