### PR TITLE
chore: increased timeout by 200s to reduce flakiness

### DIFF
--- a/samples/snippets/product_search/product_in_product_set_management.py
+++ b/samples/snippets/product_search/product_in_product_set_management.py
@@ -147,7 +147,7 @@ def purge_products_in_product_set(
         "force": force
     })
 
-    operation.result(timeout=300)
+    operation.result(timeout=500)
 
     print('Deleted products in product set.')
 # [END vision_product_search_purge_products_in_product_set]

--- a/samples/snippets/product_search/product_management.py
+++ b/samples/snippets/product_search/product_management.py
@@ -206,7 +206,7 @@ def purge_orphan_products(project_id, location, force):
         "force": force
     })
 
-    operation.result(timeout=300)
+    operation.result(timeout=500)
 
     print('Orphan products deleted.')
 # [END vision_product_search_purge_orphan_products]


### PR DESCRIPTION
In PR #152, the samples check for python [3.6](https://source.cloud.google.com/results/invocations/8b495204-fef4-4ceb-a87d-eeac130e67ce/log) and [3.8](https://source.cloud.google.com/results/invocations/68598456-9dff-4c94-8427-f777075828e2/log) failed with error `google.api_core.exceptions.RetryError: Deadline of 300.0s exceeded while calling functools.partial(<bound method PollingFuture._done_or_raise of <google.api_core.operation.Operation object at 0x7fc93a31c0b8>>)`. This PR attempts to reduce flakiness by increasing the timeout from 300s to 500s.