### PR TITLE
build: exit successfully when no samples exist

### DIFF
--- a/.kokoro/test-samples-impl.sh
+++ b/.kokoro/test-samples-impl.sh
@@ -20,9 +20,9 @@ set -eo pipefail
 # Enables `**` to include files nested inside sub-folders
 shopt -s globstar
 
-# Exit early if samples directory doesn't exist
-if [ ! -d "./samples" ]; then
-  echo "No tests run. `./samples` not found"
+# Exit early if samples don't exist
+if ! find samples -name 'requirements.txt' | grep -q .; then
+  echo "No tests run. './samples/**/requirements.txt' not found"
   exit 0
 fi
 

--- a/.kokoro/test-samples-impl.sh
+++ b/.kokoro/test-samples-impl.sh
@@ -20,9 +20,9 @@ set -eo pipefail
 # Enables `**` to include files nested inside sub-folders
 shopt -s globstar
 
-# Exit early if samples don't exist
-if ! find samples -name 'requirements.txt' | grep -q .; then
-  echo "No tests run. './samples/**/requirements.txt' not found"
+# Exit early if samples directory doesn't exist
+if [ ! -d "./samples" ]; then
+  echo "No tests run. `./samples` not found"
   exit 0
 fi
 

--- a/.kokoro/test-samples-impl.sh
+++ b/.kokoro/test-samples-impl.sh
@@ -20,9 +20,9 @@ set -eo pipefail
 # Enables `**` to include files nested inside sub-folders
 shopt -s globstar
 
-# Exit early if samples directory doesn't exist
-if [ ! -d "./samples" ]; then
-  echo "No tests run. `./samples` not found"
+# Exit early if samples don't exist
+if ! compgen -G  "./samples/**/requirements.txt" > /dev/null; then
+  echo "No tests run. './samples/**/requirements.txt' not found"
   exit 0
 fi
 

--- a/.kokoro/test-samples-impl.sh
+++ b/.kokoro/test-samples-impl.sh
@@ -21,7 +21,7 @@ set -eo pipefail
 shopt -s globstar
 
 # Exit early if samples don't exist
-if ! compgen -G  "./samples/**/requirements.txt" > /dev/null; then
+if ! find samples -name 'requirements.txt' | grep -q .; then
   echo "No tests run. './samples/**/requirements.txt' not found"
   exit 0
 fi


### PR DESCRIPTION
Fixes #<issue_number_goes_here> 🦕