### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "vision",
     "name_pretty": "Cloud Vision",
     "product_documentation": "https://cloud.google.com/vision/docs/",
-    "client_documentation": "https://googleapis.dev/python/vision/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/vision/latest",
     "issue_tracker": "https://issuetracker.google.com/issues?q=status:open%20componentid:187174",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Storage.
 .. _Vision: https://cloud.google.com/vision/
 
 .. _Google Cloud Vision: https://cloud.google.com/vision/
-.. _Client Library Documentation: https://googleapis.dev/python/vision/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/vision/latest
 .. _Product Documentation: https://cloud.google.com/vision/reference/rest/
 
 


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.